### PR TITLE
Feat/disable postcss

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,6 +84,7 @@ export default {
   build: {
     // TODO: 'vue-link' seems not to work if not transpiled by babel. Maybe I'm missing something here.
     transpile: ['vue-link'],
+    postcss: null,
   },
 
   // Generate Options

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,6 +84,7 @@ export default {
   build: {
     // TODO: 'vue-link' seems not to work if not transpiled by babel. Maybe I'm missing something here.
     transpile: ['vue-link'],
+    // Disable PostCSS – Removes "you did not set any plugins, parser, or stringifier" warning. Delete line if you use PostCSS.
     postcss: null,
   },
 


### PR DESCRIPTION
To my understanding, PostCSS is enabled by default. As we don't use it, we do not define any PostCSS plugins.
This triggers the warning _"You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js."_ multiple times on build.

Since we usually don't use PostCSS, we should disable it by default and keep it from spamming the terminal.